### PR TITLE
Add a config for LGTM.com

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,39 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '21 17 * * 6'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+
+    - run: 'mvn clean package -DskipTests -Dmaven.javadoc.skip=true --file parent/pom.xml'
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,12 @@
+path_classifiers:
+
+  # exclude tests
+  test:
+  - "**/src/test"
+
+extraction:
+  java:
+    index:
+      java_version: 8
+      build_command: "mvn clean package -DskipTests -Dmaven.javadoc.skip=true --file parent/pom.xml"
+

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -95,7 +95,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.2</version>
+				<version>3.2.0</version>
 <!-- ONLY NEEDED With jdk 1.7+ -->
 <!--
 				<configuration>


### PR DESCRIPTION
LGTM.com offers static analysis for open source project. It helps catching issues earlier (including security ones). This is based on CodeQL engine. This pull request adds a config for building and scanning json-smart-v1. Currently, the build fails

https://lgtm.com/logs/33695cdc74f4749a6779cfc6764d8cb15eda2071/lang:java

Once a report at LGTM.com is available, I can also triage findings and fix major ones.

In addition, I added a GitHub workflow that runs CodeQL scans regularly and on pull requests.

P.S. I had to update javadoc plugin version since it doesn't seem to be correct and causes the build to fail.