### PR TITLE
bugfix(#15): Correct maven-javadoc-plugin version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -95,7 +95,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.2</version>
+				<version>3.2.0</version>
 <!-- ONLY NEEDED With jdk 1.7+ -->
 <!--
 				<configuration>


### PR DESCRIPTION
Fix to correct the maven-javadoc-plugin version so it builds correctly